### PR TITLE
Modifica los tiempos de los token y creación endpoint para resumen mensual

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,5 +15,5 @@ class Config:
     JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "jwt_default_secret_key")
     
     # Duración de los tokens JWT
-    JWT_ACCESS_TOKEN_EXPIRES = timedelta(days=7)    # Access token: 7 días
-    JWT_REFRESH_TOKEN_EXPIRES = timedelta(days=30)  # Refresh token: 30 días
+    JWT_ACCESS_TOKEN_EXPIRES = timedelta(hours=1)    # Access token: 1 hora
+    JWT_REFRESH_TOKEN_EXPIRES = timedelta(days=1)  # Refresh token:  1 día


### PR DESCRIPTION
1. Ajuste de la Duración de los Tokens JWT
Se han modificado las configuraciones de los tokens JWT:
Token de Acceso (JWT_ACCESS_TOKEN_EXPIRES): Ahora expira en 1 hora.
Token de Refresco (JWT_REFRESH_TOKEN_EXPIRES): Ahora expira en 1 día.

2. Nuevo Endpoint: Resumen Mensual de Temperatura y Humedad
Se ha agregado un nuevo endpoint /api/data_tth/monthly_summary que permite obtener un resumen mensual de los datos de temperatura y humedad, agrupados por mes y con estadísticas como promedio, máximo, mínimo y un índice calculado.

Además, se incluyen notas destacadas:
Mes más caluroso.
Mes más húmedo.
Mes menos propicio para procesos agrícolas.
El endpoint también maneja correctamente el caso en que no se proporciona un rango de fechas, utilizando automáticamente:

Fecha de inicio: La fecha del registro más antiguo disponible.
Fecha de fin: El último día del mes anterior al actual.